### PR TITLE
Work with regional surface datasets

### DIFF
--- a/src/landusedata/landusepft.py
+++ b/src/landusedata/landusepft.py
@@ -85,7 +85,7 @@ def main(args):
     # this will contain different data from a future CLM landuse x pft update
     ds_output['frac_secnd'] = ds_output.frac_primr.copy(deep=True)
 
-    # ds_regrid = ds_regrid.rename_dims(dims_dict={'lat':'lsmlat','lon':'lsmlon'})
+    # ds_regrid = ds_regrid.rename({'lat':'lsmlat','lon':'lsmlon'})
 
     # Output dataset to netcdf file
     print('Writing fates landuse x pft dataset to file')

--- a/src/landusedata/luh2.py
+++ b/src/landusedata/luh2.py
@@ -75,7 +75,7 @@ def main(args):
 
         # Rename the dimensions for the output.  This needs to happen after the "LONGXY/LATIXY" assignment
         if (not 'lsmlat' in list(regrid_luh2.dims)):
-            regrid_luh2 = regrid_luh2.rename_dims({'lat':'lsmlat','lon':'lsmlon'})
+            regrid_luh2 = regrid_luh2.rename({'lat':'lsmlat','lon':'lsmlon'})
 
         # Reapply the coordinate attributes.  This is a workaround for an xarray bug (#8047)
         # Currently only need time

--- a/src/landusedata/luh2.py
+++ b/src/landusedata/luh2.py
@@ -74,8 +74,9 @@ def main(args):
             regrid_luh2["LATIXY"] = ds_regrid_target["LATIXY"] # TO DO: double check if this is strictly necessary
 
         # Rename the dimensions for the output.  This needs to happen after the "LONGXY/LATIXY" assignment
+        # and should not touch the respective coordinate variables (hence rename_dims instead of rename).
         if (not 'lsmlat' in list(regrid_luh2.dims)):
-            regrid_luh2 = regrid_luh2.rename({'lat':'lsmlat','lon':'lsmlon'})
+            regrid_luh2 = regrid_luh2.rename_dims({'lat':'lsmlat','lon':'lsmlon'})
 
         # Reapply the coordinate attributes.  This is a workaround for an xarray bug (#8047)
         # Currently only need time

--- a/src/landusedata/utils.py
+++ b/src/landusedata/utils.py
@@ -31,7 +31,7 @@ def _RegridTargetPrep(regrid_target):
     regrid_target = regrid_target.drop_vars("lon", errors="ignore")
 
     # Rename dimensions and add coordinates
-    regrid_target = regrid_target.rename_dims(dims_dict={'lsmlat':'lat','lsmlon':'lon'})
+    regrid_target = regrid_target.rename({'lsmlat':'lat','lsmlon':'lon'})
     regrid_target['lon'] = regrid_target.LONGXY.isel(lat=0)
     regrid_target['lat'] = regrid_target.LATIXY.isel(lon=0)
 

--- a/src/landusedata/utils.py
+++ b/src/landusedata/utils.py
@@ -21,6 +21,16 @@ def _RegridTargetPrep(regrid_target):
     by xesmf.  As such, this function renames the dimensions.  It also adds
     lat/lon coordinates based on the LONGXY and LATIXY variables.
     """
+
+    # Skip if lat and lon are already the dimension names
+    if "lat" in regrid_target.dims and "lon" in regrid_target.dims:
+        return regrid_target
+
+    # Drop dimension variables if they already exist
+    regrid_target = regrid_target.drop_vars("lat", errors="ignore")
+    regrid_target = regrid_target.drop_vars("lon", errors="ignore")
+
+    # Rename dimensions and add coordinates
     regrid_target = regrid_target.rename_dims(dims_dict={'lsmlat':'lat','lsmlon':'lon'})
     regrid_target['lon'] = regrid_target.LONGXY.isel(lat=0)
     regrid_target['lat'] = regrid_target.LATIXY.isel(lon=0)


### PR DESCRIPTION
This PR makes it so that the FATES land-use tool is compatible with `regrid_target_file` being a surface dataset generated by the CTSM `subset_data` script. These are different from the usual surface datasets because:
- They already have `lat` and `lon` variables, although the associated dimensions are still `lsmlat` and `lsmlon`.
- In addition to the _dimensions_ `lsmlat` and `lsmlon`, there are also _coordinates_ with those names.

Needs to be tested for compatibility with the usual kind of surface dataset. But as far as regional surface datasets, it works for my South America domain, at least for the `lupft` file (cutoff at southern edge is intentional):
![screenshot_1153](https://github.com/user-attachments/assets/035123cd-f607-4904-941f-137ac442adda)

### Remaining tasks
- [x] Check that regional `luh2` file looks okay.
- [ ] Check that runs forced with the regional outputs actually work.
- [ ] Check that outputs (`luh2` and `lupft`) are unchanged when using normal surface datasets as `regrid_target_file`.