### PR TITLE
Add argument and improve arg processing

### DIFF
--- a/src/landusedata/__main__.py
+++ b/src/landusedata/__main__.py
@@ -1,5 +1,5 @@
 from landusedata._main import main
 
-# Gaurd against import time side effects
+# Guard against import time side effects
 if __name__ == '__main__':
     raise SystemExit(main())

--- a/src/landusedata/_main.py
+++ b/src/landusedata/_main.py
@@ -12,6 +12,11 @@ def _shared_arguments(parser):
         'luh2_static_file',
         help='luh2 static data file',
     )
+    parser.add_argument(
+        '-t', '--test',
+        action='store_true',
+        help='test mode: only regrid one variable',
+    )
     return parser
 
 def main(argv=None):

--- a/src/landusedata/_main.py
+++ b/src/landusedata/_main.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 
 from landusedata.luh2 import main as luh2main
 from landusedata.landusepft import main as lupftmain
@@ -11,6 +12,11 @@ def _shared_arguments(parser):
     parser.add_argument(
         'luh2_static_file',
         help='luh2 static data file',
+    )
+    parser.add_argument(
+        '--overwrite',
+        action='store_true',
+        help='overwrite existing output file, if it exists',
     )
     parser.add_argument(
         '-t', '--test',
@@ -80,6 +86,10 @@ def main(argv=None):
 
     # Parse the arguments
     args = parser.parse_args(argv)
+
+    # Only overwrite existing output if --overwrite specified
+    if os.path.exists(args.output) and not args.overwrite:
+        raise FileExistsError(f"Output file exists; specify --overwrite to overwrite: {args.output}")
 
     # Call the default function for the given subcommand
     args.func(args)

--- a/src/landusedata/_main.py
+++ b/src/landusedata/_main.py
@@ -82,6 +82,6 @@ def main(argv=None):
     # Return successful completion
     return 0
 
-# Gaurd against import time side effects
+# Guard against import time side effects
 if __name__ == '__main__':
     raise SystemExit(main())

--- a/src/landusedata/_main.py
+++ b/src/landusedata/_main.py
@@ -91,10 +91,12 @@ def main(argv=None):
     if os.path.exists(args.output) and not args.overwrite:
         raise FileExistsError(f"Output file exists; specify --overwrite to overwrite: {args.output}")
 
-    # Create output directory, if needed.
+    # Create output directory, if needed. Otherwise, check write access.
     output_directory = os.path.dirname(args.output)
     if not os.path.exists(output_directory):
         os.makedirs(output_directory)
+    elif not os.access(output_directory, os.W_OK):
+        raise PermissionError("No write permissions in " + output_directory)
 
     # Call the default function for the given subcommand
     args.func(args)

--- a/src/landusedata/_main.py
+++ b/src/landusedata/_main.py
@@ -3,6 +3,17 @@ import argparse
 from landusedata.luh2 import main as luh2main
 from landusedata.landusepft import main as lupftmain
 
+def _shared_arguments(parser):
+    parser.add_argument(
+        'regrid_target_file',
+        help='target surface data file with desired grid resolution',
+    )
+    parser.add_argument(
+        'luh2_static_file',
+        help='luh2 static data file',
+    )
+    return parser
+
 def main(argv=None):
 
     # Define top level parser
@@ -23,11 +34,11 @@ def main(argv=None):
     luh2_parser.set_defaults(func=luh2main)
     lupft_parser.set_defaults(func=lupftmain)
 
+    # Shared arguments
+    luh2_parser = _shared_arguments(luh2_parser)
+    lupft_parser = _shared_arguments(lupft_parser)
+
     # LUH2 subparser arguments
-    luh2_parser.add_argument('regrid_target_file',
-                             help='target surface data file with desired grid resolution')
-    luh2_parser.add_argument("luh2_static_file",
-                             help = "luh2 static data file")
     luh2_parser.add_argument('luh2_states_file',
                              help = "full path of luh2 raw states file")
     luh2_parser.add_argument('luh2_transitions_file',
@@ -50,10 +61,6 @@ def main(argv=None):
                              help = "output filename")
 
     # Landuse x pft subparser arguments
-    lupft_parser.add_argument('regrid_target_file',
-                             help='target surface data file with desired grid resolution')
-    lupft_parser.add_argument('luh2_static_file',
-                             help = "luh2 static data file")
     lupft_parser.add_argument('clm_luhforest_file',
                               help = "CLM5_current_luhforest_deg025.nc")
     lupft_parser.add_argument('clm_luhpasture_file',

--- a/src/landusedata/_main.py
+++ b/src/landusedata/_main.py
@@ -91,6 +91,11 @@ def main(argv=None):
     if os.path.exists(args.output) and not args.overwrite:
         raise FileExistsError(f"Output file exists; specify --overwrite to overwrite: {args.output}")
 
+    # Create output directory, if needed.
+    output_directory = os.path.dirname(args.output)
+    if not os.path.exists(output_directory):
+        os.makedirs(output_directory)
+
     # Call the default function for the given subcommand
     args.func(args)
 

--- a/src/landusedata/landusepft.py
+++ b/src/landusedata/landusepft.py
@@ -81,9 +81,15 @@ def main(args):
         # Append the new dataset to the output dataset
         ds_output = ds_output.merge(ds_regrid)
 
+        # Stop regridding if in test mode
+        if args.test:
+            print("-t/--test specified, so stopping here")
+            break
+
     # Duplicate the 'primary' data array into a 'secondary' data array.  Eventually
     # this will contain different data from a future CLM landuse x pft update
-    ds_output['frac_secnd'] = ds_output.frac_primr.copy(deep=True)
+    if not args.test:
+        ds_output['frac_secnd'] = ds_output.frac_primr.copy(deep=True)
 
     # ds_regrid = ds_regrid.rename({'lat':'lsmlat','lon':'lsmlon'})
 

--- a/src/landusedata/landusepft.py
+++ b/src/landusedata/landusepft.py
@@ -85,7 +85,7 @@ def main(args):
     # this will contain different data from a future CLM landuse x pft update
     ds_output['frac_secnd'] = ds_output.frac_primr.copy(deep=True)
 
-    # ds_regrid = ds_regrid.rename_dims(dims_dict={'lat':'lsmlat','lon':'lsmlon'})
+    # ds_regrid = ds_regrid.rename({'lat':'lsmlat','lon':'lsmlon'})
 
     # Output dataset to netcdf file
     print('Writing fates landuse x pft dataset to file')

--- a/src/landusedata/luh2.py
+++ b/src/landusedata/luh2.py
@@ -50,7 +50,8 @@ def main(args):
         # Regrid the luh2 data to the target grid
         # TO DO: provide a check for the save argument based on the input arguments
         regrid_luh2,regridder_luh2 = RegridConservative(dataset, ds_regrid_target,
-                                                        args.regridder_weights, regrid_reuse)
+                                                        args.regridder_weights, regrid_reuse,
+                                                        args.test)
 
         # Regrid the inverted ice/water fraction data to the target grid
         regrid_land_fraction = regridder_luh2(ds_luh2_static)
@@ -60,7 +61,8 @@ def main(args):
         regrid_luh2 = regrid_luh2 / regrid_land_fraction.landfrac
 
         # Correct the state sum (checks if argument passed is state file in the function)
-        regrid_luh2 = CorrectStateSum(regrid_luh2)
+        if not args.test:
+            regrid_luh2 = CorrectStateSum(regrid_luh2)
 
         # Add additional required variables for the host land model
         # Add 'YEAR' as a variable.
@@ -95,6 +97,10 @@ def main(args):
         # the previously generated weights file is reused
         if (not(regrid_reuse)):
             regrid_reuse = True
+
+        # Only process one dataset if in test mode
+        if args.test:
+            break
 
     # Write the files
     # TO DO: add check to handle if the user enters the full path

--- a/src/landusedata/luh2.py
+++ b/src/landusedata/luh2.py
@@ -74,6 +74,7 @@ def main(args):
             regrid_luh2["LATIXY"] = ds_regrid_target["LATIXY"] # TO DO: double check if this is strictly necessary
 
         # Rename the dimensions for the output.  This needs to happen after the "LONGXY/LATIXY" assignment
+        # and should not touch the respective coordinate variables (hence rename_dims instead of rename).
         if (not 'lsmlat' in list(regrid_luh2.dims)):
             regrid_luh2 = regrid_luh2.rename_dims({'lat':'lsmlat','lon':'lsmlon'})
 

--- a/src/landusedata/regrid.py
+++ b/src/landusedata/regrid.py
@@ -38,25 +38,23 @@ def RegridLoop(ds_to_regrid, regridder):
     first_var = False
     for i, var in enumerate(ds_to_regrid):
 
-        # Skip time variable
-        if (not "time" in var):
+        # Skip time variable and only regrid variables that match the lat/lon shape.
+        do_regrid = not "time" in var
+        do_regrid = do_regrid and \
+            ds_to_regrid[var][0].shape == (ds_to_regrid.lat.shape[0], ds_to_regrid.lon.shape[0])
+        if do_regrid :
+            print("regridding variable {}/{}: {}".format(i+1, varlen, var))
 
-            # Only regrid variables that match the lat/lon shape.
-            if (ds_to_regrid[var][0].shape == (ds_to_regrid.lat.shape[0], ds_to_regrid.lon.shape[0])):
-                print("regridding variable {}/{}: {}".format(i+1, varlen, var))
+            # For the first non-coordinate variable, copy and regrid the dataset as a whole.
+            # This makes sure to correctly include the lat/lon in the regridding.
+            if (not(first_var)):
+                ds_regrid = ds_to_regrid[var].to_dataset() # convert data array to dataset
+                ds_regrid = regridder(ds_regrid)
+                first_var = True
 
-                # For the first non-coordinate variable, copy and regrid the dataset as a whole.
-                # This makes sure to correctly include the lat/lon in the regridding.
-                if (not(first_var)):
-                    ds_regrid = ds_to_regrid[var].to_dataset() # convert data array to dataset
-                    ds_regrid = regridder(ds_regrid)
-                    first_var = True
-
-                # Once the first variable has been included, then we can regrid by variable
-                else:
-                    ds_regrid[var] = regridder(ds_to_regrid[var])
+            # Once the first variable has been included, then we can regrid by variable
             else:
-                print("skipping variable {}/{}: {}".format(i+1, varlen, var))
+                ds_regrid[var] = regridder(ds_to_regrid[var])
         else:
             print("skipping variable {}/{}: {}".format(i+1, varlen, var))
 

--- a/src/landusedata/regrid.py
+++ b/src/landusedata/regrid.py
@@ -36,29 +36,29 @@ def RegridLoop(ds_to_regrid, regridder):
     ds_varnames = list(ds_to_regrid.variables.keys())
     varlen = len(ds_to_regrid.variables)
     first_var = False
-    for i in range(varlen):
+    for i, var in enumerate(ds_to_regrid):
 
         # Skip time variable
-        if (not "time" in ds_varnames[i]):
+        if (not "time" in var):
 
             # Only regrid variables that match the lat/lon shape.
-            if (ds_to_regrid[ds_varnames[i]][0].shape == (ds_to_regrid.lat.shape[0], ds_to_regrid.lon.shape[0])):
-                print("regridding variable {}/{}: {}".format(i+1, varlen, ds_varnames[i]))
+            if (ds_to_regrid[var][0].shape == (ds_to_regrid.lat.shape[0], ds_to_regrid.lon.shape[0])):
+                print("regridding variable {}/{}: {}".format(i+1, varlen, var))
 
                 # For the first non-coordinate variable, copy and regrid the dataset as a whole.
                 # This makes sure to correctly include the lat/lon in the regridding.
                 if (not(first_var)):
-                    ds_regrid = ds_to_regrid[ds_varnames[i]].to_dataset() # convert data array to dataset
+                    ds_regrid = ds_to_regrid[var].to_dataset() # convert data array to dataset
                     ds_regrid = regridder(ds_regrid)
                     first_var = True
 
                 # Once the first variable has been included, then we can regrid by variable
                 else:
-                    ds_regrid[ds_varnames[i]] = regridder(ds_to_regrid[ds_varnames[i]])
+                    ds_regrid[var] = regridder(ds_to_regrid[var])
             else:
-                print("skipping variable {}/{}: {}".format(i+1, varlen, ds_varnames[i]))
+                print("skipping variable {}/{}: {}".format(i+1, varlen, var))
         else:
-            print("skipping variable {}/{}: {}".format(i+1, varlen, ds_varnames[i]))
+            print("skipping variable {}/{}: {}".format(i+1, varlen, var))
 
     print("\n")
     return(ds_regrid)

--- a/src/landusedata/regrid.py
+++ b/src/landusedata/regrid.py
@@ -36,7 +36,7 @@ def RegridLoop(ds_to_regrid, regridder):
     ds_varnames = list(ds_to_regrid.variables.keys())
     varlen = len(ds_to_regrid.variables)
     first_var = False
-    for i in range(varlen-1):
+    for i in range(varlen):
 
         # Skip time variable
         if (not "time" in ds_varnames[i]):

--- a/src/landusedata/regrid.py
+++ b/src/landusedata/regrid.py
@@ -37,16 +37,17 @@ def RegridLoop(ds_to_regrid, regridder):
     varlen = len(ds_to_regrid.variables)
     first_var = True
     for i, var in enumerate(ds_to_regrid):
+        msg_text = " variable {}/{}: {}\n".format(i+1, varlen, var)
 
         # Skip time variable and only regrid variables that match the lat/lon shape.
         do_regrid = not "time" in var
         do_regrid = do_regrid and \
             ds_to_regrid[var][0].shape == (ds_to_regrid.lat.shape[0], ds_to_regrid.lon.shape[0])
         if not do_regrid :
-            print("skipping variable {}/{}: {}".format(i+1, varlen, var))
+            print("skipping" + msg_text)
             continue
 
-        print("regridding variable {}/{}: {}".format(i+1, varlen, var))
+        print("regridding" + msg_text)
 
         # For the first non-coordinate variable, copy and regrid the dataset as a whole.
         # This makes sure to correctly include the lat/lon in the regridding.
@@ -59,5 +60,4 @@ def RegridLoop(ds_to_regrid, regridder):
         else:
             ds_regrid[var] = regridder(ds_to_regrid[var])
 
-    print("\n")
     return(ds_regrid)

--- a/src/landusedata/regrid.py
+++ b/src/landusedata/regrid.py
@@ -42,21 +42,22 @@ def RegridLoop(ds_to_regrid, regridder):
         do_regrid = not "time" in var
         do_regrid = do_regrid and \
             ds_to_regrid[var][0].shape == (ds_to_regrid.lat.shape[0], ds_to_regrid.lon.shape[0])
-        if do_regrid :
-            print("regridding variable {}/{}: {}".format(i+1, varlen, var))
-
-            # For the first non-coordinate variable, copy and regrid the dataset as a whole.
-            # This makes sure to correctly include the lat/lon in the regridding.
-            if (not(first_var)):
-                ds_regrid = ds_to_regrid[var].to_dataset() # convert data array to dataset
-                ds_regrid = regridder(ds_regrid)
-                first_var = True
-
-            # Once the first variable has been included, then we can regrid by variable
-            else:
-                ds_regrid[var] = regridder(ds_to_regrid[var])
-        else:
+        if not do_regrid :
             print("skipping variable {}/{}: {}".format(i+1, varlen, var))
+            continue
+
+        print("regridding variable {}/{}: {}".format(i+1, varlen, var))
+
+        # For the first non-coordinate variable, copy and regrid the dataset as a whole.
+        # This makes sure to correctly include the lat/lon in the regridding.
+        if (not(first_var)):
+            ds_regrid = ds_to_regrid[var].to_dataset() # convert data array to dataset
+            ds_regrid = regridder(ds_regrid)
+            first_var = True
+
+        # Once the first variable has been included, then we can regrid by variable
+        else:
+            ds_regrid[var] = regridder(ds_to_regrid[var])
 
     print("\n")
     return(ds_regrid)

--- a/src/landusedata/regrid.py
+++ b/src/landusedata/regrid.py
@@ -1,12 +1,12 @@
 import xesmf as xe
 
-def RegridConservative(ds_to_regrid, ds_regrid_target, regridder_weights, regrid_reuse):
+def RegridConservative(ds_to_regrid, ds_regrid_target, regridder_weights, regrid_reuse, test):
 
     # define the regridder transformation
     regridder = GenerateRegridder(ds_to_regrid, ds_regrid_target, regridder_weights, regrid_reuse)
 
     # Loop through the variables to regrid
-    ds_regrid = RegridLoop(ds_to_regrid, regridder)
+    ds_regrid = RegridLoop(ds_to_regrid, regridder, test)
 
     return (ds_regrid, regridder)
 
@@ -27,7 +27,7 @@ def GenerateRegridder(ds_to_regrid, ds_regrid_target, regridder_weights_file, re
 
     return(regridder)
 
-def RegridLoop(ds_to_regrid, regridder):
+def RegridLoop(ds_to_regrid, regridder, test):
 
     # To Do: implement this with dask
     print("\nRegridding")
@@ -59,5 +59,10 @@ def RegridLoop(ds_to_regrid, regridder):
         # Once the first variable has been included, then we can regrid by variable
         else:
             ds_regrid[var] = regridder(ds_to_regrid[var])
+
+        # Stop regridding if in test mode
+        if test:
+            print("-t/--test specified, so stopping here")
+            break
 
     return(ds_regrid)

--- a/src/landusedata/regrid.py
+++ b/src/landusedata/regrid.py
@@ -35,7 +35,7 @@ def RegridLoop(ds_to_regrid, regridder):
     # Loop through the variables one at a time to conserve memory
     ds_varnames = list(ds_to_regrid.variables.keys())
     varlen = len(ds_to_regrid.variables)
-    first_var = False
+    first_var = True
     for i, var in enumerate(ds_to_regrid):
 
         # Skip time variable and only regrid variables that match the lat/lon shape.
@@ -50,10 +50,10 @@ def RegridLoop(ds_to_regrid, regridder):
 
         # For the first non-coordinate variable, copy and regrid the dataset as a whole.
         # This makes sure to correctly include the lat/lon in the regridding.
-        if (not(first_var)):
+        if first_var:
             ds_regrid = ds_to_regrid[var].to_dataset() # convert data array to dataset
             ds_regrid = regridder(ds_regrid)
-            first_var = True
+            first_var = False
 
         # Once the first variable has been included, then we can regrid by variable
         else:

--- a/src/landusedata/utils.py
+++ b/src/landusedata/utils.py
@@ -21,7 +21,17 @@ def _RegridTargetPrep(regrid_target):
     by xesmf.  As such, this function renames the dimensions.  It also adds
     lat/lon coordinates based on the LONGXY and LATIXY variables.
     """
-    regrid_target = regrid_target.rename_dims(dims_dict={'lsmlat':'lat','lsmlon':'lon'})
+
+    # Skip if lat and lon are already the dimension names
+    if "lat" in regrid_target.dims and "lon" in regrid_target.dims:
+        return regrid_target
+
+    # Drop dimension variables if they already exist
+    regrid_target = regrid_target.drop_vars("lat", errors="ignore")
+    regrid_target = regrid_target.drop_vars("lon", errors="ignore")
+
+    # Rename dimensions and add coordinates
+    regrid_target = regrid_target.rename({'lsmlat':'lat','lsmlon':'lon'})
     regrid_target['lon'] = regrid_target.LONGXY.isel(lat=0)
     regrid_target['lat'] = regrid_target.LATIXY.isel(lon=0)
 


### PR DESCRIPTION
_Depends on merges of #23 and #24. Will rebase once those are in._

- Add `-t`/`--test` option, which causes only one variable to be regridded.
- Require `--overwrite` to overwrite existing output. Resolves NGEET/tools-fates-landusedata#16.
- Make output parent directory, if needed. Resolves NGEET/tools-fates-landusedata#17.
- Check for write access before processing. Resolves NGEET/tools-fates-landusedata#18.