### PR TITLE
Add conda package build and publishing pipeline

### DIFF
--- a/.github/workflows/lockfile-generation.yml
+++ b/.github/workflows/lockfile-generation.yml
@@ -1,7 +1,12 @@
 name: Generate a lockfile for reproducible conda environments
 
+# This workflow should be triggered when the pyproject.toml file is modified.
+# It will also regenerate the lockfile on a regular schedule to ensure it remains up-to-date.
+
 on:
   workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * MON'  # Every Monday at midnight UTC
   pull_request:
     types: [opened, reopened, synchronize]
     paths:

--- a/.github/workflows/lockfile-generation.yml
+++ b/.github/workflows/lockfile-generation.yml
@@ -28,5 +28,5 @@ jobs:
 
         - name: Generate conda-lock.yml
           run: | 
-           conda-lock -f pyproject.toml -p linux-64 -o conda-lock.yml
+           conda-lock -f pyproject.toml -p linux-64
            

--- a/.github/workflows/lockfile-generation.yml
+++ b/.github/workflows/lockfile-generation.yml
@@ -12,7 +12,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-
         - name: Checkout repository
           uses: actions/checkout@v4
 
@@ -29,4 +28,11 @@ jobs:
         - name: Generate conda-lock.yml
           run: | 
            conda-lock -f pyproject.toml -p linux-64
+          
+        - name: Upload conda-lock.yml
+          uses: actions/upload-artifact@v4
+          with:
+            name: conda-lock.yml
+            path: conda-lock.yml
+
            

--- a/.github/workflows/lockfile-generation.yml
+++ b/.github/workflows/lockfile-generation.yml
@@ -1,0 +1,31 @@
+name: Generate a lockfile for reproducible conda environments
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    paths:
+    - 'pyproject.toml'
+
+jobs:
+  generate-lockfile:
+    runs-on: ubuntu-latest
+
+    steps:
+
+        - name: Checkout repository
+          uses: actions/checkout@v4
+
+        - name: Set up Python
+          uses: actions/setup-python@v5
+          with:
+            python-version: "3.12"
+
+        - name: Install conda-lock
+          run: |
+            python -m pip install --upgrade pip
+            pip install conda-lock  
+
+        - name: Generate conda-lock.yml
+          run: | 
+           conda-lock lock -f pyproject.toml -p linux-64 -o conda-lock.yml

--- a/.github/workflows/lockfile-generation.yml
+++ b/.github/workflows/lockfile-generation.yml
@@ -28,4 +28,5 @@ jobs:
 
         - name: Generate conda-lock.yml
           run: | 
-           conda-lock lock -f pyproject.toml -p linux-64 -o conda-lock.yml
+           conda-lock -f pyproject.toml -p linux-64 -o conda-lock.yml
+           

--- a/.github/workflows/package-build.yml
+++ b/.github/workflows/package-build.yml
@@ -32,4 +32,4 @@ jobs:
         run: conda install -c conda-forge grayskull conda-build anaconda-client -y
 
       - name: Generate meta.yaml with grayskull
-        run: grayskull pypi {{ github.repositoryUrl }} 
+        run: grayskull pypi ${{ github.repositoryUrl }} 

--- a/.github/workflows/package-build.yml
+++ b/.github/workflows/package-build.yml
@@ -32,7 +32,7 @@ jobs:
         run: conda install -c conda-forge grayskull conda-build anaconda-client -y
 
       - name: Generate meta.yaml with grayskull
-        run: grayskull pypi ${{ github.event.repository.html_url }}}}" 
+        run: grayskull pypi ${{ github.event.repository.html_url }}
 
       - name: Build conda package
         run: conda build ${{ github.event.repository.name}}

--- a/.github/workflows/package-build.yml
+++ b/.github/workflows/package-build.yml
@@ -19,7 +19,6 @@ jobs:
         shell: bash -el {0}
 
     steps:
-
       - name: Set up Miniconda
         uses: conda-incubator/setup-miniconda@v3
         with:
@@ -35,4 +34,13 @@ jobs:
         run: grayskull pypi ${{ github.event.repository.html_url }}
 
       - name: Build conda package
-        run: conda build ${{ github.event.repository.name}}
+        run: conda build ${{ github.event.repository.name }}
+
+      - name: Upload conda package to Anaconda Cloud
+        run: |
+          anaconda login \
+            --username $${{ secrets.ANACONDA_USERNAME }} \
+            --password $${{ secrets.ANACONDA_PASSWORD }}
+          anaconda upload --user ngeetropics \
+            $${{ github.event.repository.name }} \
+            /usr/share/miniconda/envs/test/conda-bld/noarch/${{ github.event.repository.name }}-0.0.0-py_0.conda

--- a/.github/workflows/package-build.yml
+++ b/.github/workflows/package-build.yml
@@ -23,7 +23,6 @@ jobs:
       - name: Set up Miniconda
         uses: conda-incubator/setup-miniconda@v3
         with:
-          activate-environment: base
           python-version: "3.12"
           channels: conda-forge
           channel-priority: flexible

--- a/.github/workflows/package-build.yml
+++ b/.github/workflows/package-build.yml
@@ -8,8 +8,6 @@ on:
   workflow_dispatch:
   release:
     types: [published]
-  pull_request:
-    types: [opened, reopened, synchronize]
 
 jobs:
   build-and-upload:

--- a/.github/workflows/package-build.yml
+++ b/.github/workflows/package-build.yml
@@ -32,4 +32,7 @@ jobs:
         run: conda install -c conda-forge grayskull conda-build anaconda-client -y
 
       - name: Generate meta.yaml with grayskull
-        run: grayskull pypi "https://github.com/${{ github.repository}}" 
+        run: grayskull pypi ${{ github.event.repository.html_url }}}}" 
+
+      - name: Build conda package
+        run: conda build ${{ github.event.repository.name}}

--- a/.github/workflows/package-build.yml
+++ b/.github/workflows/package-build.yml
@@ -32,4 +32,4 @@ jobs:
         run: conda install -c conda-forge grayskull conda-build anaconda-client -y
 
       - name: Generate meta.yaml with grayskull
-        run: grayskull pypi ${{ github.repositoryUrl }} 
+        run: grayskull pypi "https://github.com/${{ github.repository}}" 

--- a/.github/workflows/package-build.yml
+++ b/.github/workflows/package-build.yml
@@ -1,0 +1,36 @@
+name: Build package and upload
+
+# This workflow currently assumes that main has been successfully tested and passes.  This should
+# eventually call a test workflow as a final check.  Or the workflow coudl automatically trigged a release
+# once a pull request has been merged and all tests pass.
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  build-and-upload:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -el {0}
+
+    steps:
+
+      - name: Set up Miniconda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          activate-environment: base
+          python-version: "3.12"
+          channels: conda-forge
+          channel-priority: flexible
+          show-channel-urls: true
+
+      - name: Install build and publishing tools
+        run: conda install -c conda-forge grayskull conda-build anaconda-client -y
+
+      - name: Generate meta.yaml with grayskull
+        run: grayskull pypi {{ github.repositoryUrl }} 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ addopts = [
 
 [tool.conda-lock]
 platforms = "linux-64"
-channels = ["conda-forge", "ngeetropics"]
+channels = ["conda-forge", "defaults", "ngeetropics",]
 
 [project.scripts]
 fates-landusedata = "landusedata._main:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,5 +49,10 @@ addopts = [
     "--verbose",
     "--color=yes",
 ]
+
+[tool.conda-lock]
+platforms = "linux-64"
+channels = ["conda-forge", "ngeetropics"]
+
 [project.scripts]
 fates-landusedata = "landusedata._main:main"


### PR DESCRIPTION
This workflow will use `grayskull` to procedurally generate the `meta.yaml` file to be passed to `conda-build`.  Note that due to an [existing issue in conda-build](https://github.com/conda/conda-build/issues/5489), it is difficult to produce fully reproducible packages via a lockfile at this time.  That said, providing an alternate method of installing the package from a lockfile is being investigated.